### PR TITLE
Fix parameter mismatch when invoking post functions

### DIFF
--- a/bgs_report.py
+++ b/bgs_report.py
@@ -66,9 +66,8 @@ async def get_faction_influence_in_system(session, faction_name, system_name):
         print(f"[ERROR] Influence not retrievable for {faction_name} in {system_name}: {e}")
     return None
 
-async def post_report():
+async def post_report(client: discord.Client):
     print("\n🚀 Starting BGS Report...")
-    await client.login(TOKEN)
 
     async with aiohttp.ClientSession() as session:
         for channel_id, faction_name in CHANNEL_FACTION_MAP.items():
@@ -180,9 +179,14 @@ async def post_report():
                     embed=discord.Embed().set_image(url="https://media.tenor.com/epKSpUp4d8sAAAAC/anakin-obiwan-star-wars.gif")
                 )
 
-    await client.close()
     print("\n👋 Bot session ended.")
 
 if __name__ == "__main__":
     print("✅ Script geladen und wird gestartet...")
-    asyncio.run(post_report())
+
+    async def main():
+        await client.login(TOKEN)
+        await post_report(client)
+        await client.close()
+
+    asyncio.run(main())

--- a/tick_check.py
+++ b/tick_check.py
@@ -19,7 +19,7 @@ intents.guilds = True
 
 client = discord.Client(intents=intents)
 
-async def fetch_last_tick_from_channel(channel: discord.TextChannel) -> str | None:
+async def fetch_last_tick_from_channel(client: discord.Client, channel: discord.TextChannel) -> str | None:
     async for message in channel.history(limit=50):
         if message.author == client.user and message.embeds:
             embed = message.embeds[0]
@@ -30,7 +30,7 @@ async def fetch_last_tick_from_channel(channel: discord.TextChannel) -> str | No
                     return match.group(1)
     return None
 
-async def post_tick_time():
+async def post_tick_time(client: discord.Client):
     async with aiohttp.ClientSession() as session:
         try:
             async with session.get(TICK_URL, timeout=15) as response:
@@ -48,7 +48,7 @@ async def post_tick_time():
 
     for channel_id in CHANNEL_IDS:
         channel = await client.fetch_channel(channel_id)
-        last_tick = await fetch_last_tick_from_channel(channel)
+        last_tick = await fetch_last_tick_from_channel(client, channel)
 
         print(f"[DEBUG] Channel {channel.name} last_tick: {last_tick}")
         print(f"[DEBUG] Current fetched tick: {current_tick}")
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 
     async def main():
         await client.login(TOKEN)
-        await post_tick_time()
+        await post_tick_time(client)
         await client.close()
 
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- pass logged in client to `post_tick_time` and `post_report`
- adjust each module to accept the client parameter when run standalone

## Testing
- `python -m py_compile tick_check.py bgs_report.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_687d6394fd508333ba98aa3dcf8d9dfd