### PR TITLE
Run EDDN listener alongside bot with graceful shutdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ discord.py==2.3.2
 aiohttp
 python-dotenv
 
+websocket-client
+pyzmq
+


### PR DESCRIPTION
## Summary
- start EDDN listener on startup and stop it gracefully when the bot exits
- include websocket-client and pyzmq dependencies

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement websocket-client)*

------
https://chatgpt.com/codex/tasks/task_e_68bcde941ad08333ba5455dd1be596e6